### PR TITLE
DLS-8727 Increase Lock TTL to 2 minutes

### DIFF
--- a/app/uk/gov/hmrc/helptosavereminder/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/helptosavereminder/config/AppConfig.scala
@@ -33,7 +33,7 @@ class AppConfig @Inject() (val config: Configuration, val servicesConfig: Servic
 
   val userScheduleCronExpression: String = config.getOptional[String](s"userScheduleCronExpression").getOrElse("")
 
-  val defaultRepoLockPeriod: Int = 55
+  val defaultRepoLockPeriod: Int = 120
 
   val repoLockPeriod: Int = config.getOptional[Int](s"mongodb.repoLockPeriod").getOrElse(defaultRepoLockPeriod)
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -85,7 +85,7 @@ metrics {
 
 mongodb {
   uri = "mongodb://localhost:27017/help-to-save-reminder"
-  repoLockPeriod = 55
+  repoLockPeriod = 120
 }
 
 # HtsUserSchedule cron Expression


### PR DESCRIPTION
The job runs on a 2 minute schedule on production. While there is no timeout functionality (the job won't cancel if it takes longer than the lock TTL), another app can reacquire the lock resulting in a silent failure (both jobs will run at the same time). To prevent this, we increase the lock TTL to 2 minutes (same window as the regularly scheduled job).

If the job finishes (or crashes) earlier, the lock will be released anyway, so it's only relevant for unexpected application crashes.